### PR TITLE
Cancel any previous hide view request before showing.

### DIFF
--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -184,6 +184,8 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 }
 
 - (void) show:(BOOL)animated name:(NSString*) name {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideAnimated) object:nil];
+
     [self showOrHide:NO animated:animated name:name];
 }
 


### PR DESCRIPTION
- (void) show:(BOOL)animated name:(NSString*) name {
  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideAnimated) object:nil];
  
  [self showOrHide:NO animated:animated name:name];
  }

This patch prevents the view from disappearing by previous queued hide request.
