### PR TITLE
GCDiscreetNotificationView visible during flip transition of iPhone only utility app running on iPad

### DIFF
--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -212,6 +212,8 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         [self placeOnGrid];
         
         if (animated) [UIView commitAnimations]; 
+
+        self.label.hidden = hide;
     }
 }
 


### PR DESCRIPTION
Guillaume,

I've had GCDiscreetNotificationView integrated in to my app for a little while and it works very well. Thanks for your contribution.

I did notice a small bug that occurs in the following situation:
- GCDiscreetNotificationView added to the main view of a utility-style app (i.e. one that flips like the built in Weather and Stocks apps).
- GCDiscreetNotificationView is currently hidden
- App is an iPhone-only app running on the iPad in the iPhone "emulation" view

In this situation, the GCDiscreetNotificationView will be visible during the flip to and from the main view.

This patch corrects this problem.

Let me know if you have questions.

Thanks again,
Brad
