### PR TITLE
Add optional line of secondary text to the notification

### DIFF
--- a/Demo/Classes/DemoViewController.h
+++ b/Demo/Classes/DemoViewController.h
@@ -15,6 +15,7 @@
 @property (nonatomic, retain) IBOutlet UISwitch *activitySwitch;
 @property (nonatomic, retain) IBOutlet UISwitch *topBottomSwitch;
 @property (nonatomic, retain) IBOutlet UITextField *textField;
+@property (nonatomic, retain) IBOutlet UITextField *secondaryTextField;
 @property (nonatomic, retain) GCDiscreetNotificationView *notificationView;
 
 - (IBAction) changeActivity:(id) sender;

--- a/Demo/Classes/DemoViewController.m
+++ b/Demo/Classes/DemoViewController.m
@@ -14,6 +14,7 @@
 @synthesize activitySwitch;
 @synthesize topBottomSwitch;
 @synthesize textField;
+@synthesize secondaryTextField;
 @synthesize notificationView;
 
 // Implement viewDidLoad to do additional setup after loading the view, typically from a nib.
@@ -21,9 +22,10 @@
     [super viewDidLoad];
     
     notificationView = [[GCDiscreetNotificationView alloc] initWithText:self.textField.text 
-									     showActivity:self.activitySwitch.on 
-								     inPresentationMode:self.topBottomSwitch.on ?  GCDiscreetNotificationViewPresentationModeTop : GCDiscreetNotificationViewPresentationModeBottom
-										     inView:self.view];
+                                                          secondaryText:self.secondaryTextField.text
+                                                           showActivity:self.activitySwitch.on 
+                                                     inPresentationMode:self.topBottomSwitch.on ?  GCDiscreetNotificationViewPresentationModeTop : GCDiscreetNotificationViewPresentationModeBottom
+                                                                 inView:self.view];
 }
 
 - (void) show {
@@ -47,8 +49,14 @@
 }
 
 - (BOOL) textFieldShouldReturn:(UITextField *)aTextField {
-    [self.textField resignFirstResponder];
-    [self.notificationView setTextLabel:self.textField.text animated:YES];
+    if (aTextField == textField) {
+        [self.textField resignFirstResponder];
+        [self.notificationView setTextLabel:self.textField.text animated:YES];
+    }
+    else {
+        [self.secondaryTextField resignFirstResponder];
+        [self.notificationView setSecondaryTextLabel:self.secondaryTextField.text animated:YES];
+    }
     return NO;
 }
 
@@ -59,6 +67,8 @@
     topBottomSwitch = nil;
     [textField release];
     textField = nil;
+    [secondaryTextField release];
+    secondaryTextField = nil;
     [notificationView release];
     notificationView = nil;
     

--- a/Demo/Classes/DemoViewController.m
+++ b/Demo/Classes/DemoViewController.m
@@ -29,6 +29,9 @@
 }
 
 - (void) show {
+    [self.textField resignFirstResponder];
+    [self.secondaryTextField resignFirstResponder];
+    
     [self.notificationView show:YES];
 }
 
@@ -48,7 +51,7 @@
     [self.notificationView setPresentationMode:self.topBottomSwitch.on ?  GCDiscreetNotificationViewPresentationModeTop : GCDiscreetNotificationViewPresentationModeBottom];
 }
 
-- (BOOL) textFieldShouldReturn:(UITextField *)aTextField {
+- (void) textFieldDidEndEditing:(UITextField *)aTextField {
     if (aTextField == textField) {
         [self.textField resignFirstResponder];
         [self.notificationView setTextLabel:self.textField.text animated:YES];
@@ -57,7 +60,6 @@
         [self.secondaryTextField resignFirstResponder];
         [self.notificationView setSecondaryTextLabel:self.secondaryTextField.text animated:YES];
     }
-    return NO;
 }
 
 - (void)dealloc {

--- a/Demo/Classes/DemoViewController.m
+++ b/Demo/Classes/DemoViewController.m
@@ -54,12 +54,26 @@
 - (void) textFieldDidEndEditing:(UITextField *)aTextField {
     if (aTextField == textField) {
         [self.textField resignFirstResponder];
-        [self.notificationView setTextLabel:self.textField.text animated:YES];
+        [self.notificationView setTextLabel:self.textField.text animated:NO];
     }
     else {
         [self.secondaryTextField resignFirstResponder];
-        [self.notificationView setSecondaryTextLabel:self.secondaryTextField.text animated:YES];
+        [self.notificationView setSecondaryTextLabel:self.secondaryTextField.text animated:NO];
     }
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)aTextField
+{
+    if (aTextField == textField) {
+        [self.textField resignFirstResponder];
+        [self.notificationView setTextLabel:self.textField.text animated:NO];
+    }
+    else {
+        [self.secondaryTextField resignFirstResponder];
+        [self.notificationView setSecondaryTextLabel:self.secondaryTextField.text animated:NO];
+    }
+
+    return YES;
 }
 
 - (void)dealloc {

--- a/Demo/DemoViewController.xib
+++ b/Demo/DemoViewController.xib
@@ -2,13 +2,13 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
 		<int key="IBDocument.SystemTarget">1056</int>
-		<string key="IBDocument.SystemVersion">11A459e</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1565</string>
-		<string key="IBDocument.AppKitVersion">1121.2</string>
-		<string key="IBDocument.HIToolboxVersion">557.00</string>
+		<string key="IBDocument.SystemVersion">10J869</string>
+		<string key="IBDocument.InterfaceBuilderVersion">1306</string>
+		<string key="IBDocument.AppKitVersion">1038.35</string>
+		<string key="IBDocument.HIToolboxVersion">461.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">521</string>
+			<string key="NS.object.0">301</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -142,7 +142,6 @@
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
-						<bool key="IBUIOn">YES</bool>
 					</object>
 					<object class="IBUILabel" id="437425926">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -184,7 +183,7 @@
 						<string key="NSFrame">{{20, 184}, {280, 31}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="1036676565"/>
+						<reference key="NSNextKeyView" ref="489647291"/>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -197,6 +196,34 @@
 							<object class="NSColorSpace" key="NSCustomColorSpace" id="498234865">
 								<int key="NSID">2</int>
 							</object>
+						</object>
+						<bool key="IBUIClearsOnBeginEditing">YES</bool>
+						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
+						<float key="IBUIMinimumFontSize">17</float>
+						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
+							<int key="IBUIAutocorrectionType">1</int>
+							<int key="IBUIReturnKeyType">9</int>
+							<bool key="IBUIEnablesReturnKeyAutomatically">YES</bool>
+							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						</object>
+					</object>
+					<object class="IBUITextField" id="489647291">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 223}, {280, 31}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="1036676565"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClearsContextBeforeDrawing">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<string key="IBUIText">SecondaryTextValue</string>
+						<int key="IBUIBorderStyle">3</int>
+						<object class="NSColor" key="IBUITextColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MAA</bytes>
+							<reference key="NSCustomColorSpace" ref="498234865"/>
 						</object>
 						<bool key="IBUIClearsOnBeginEditing">YES</bool>
 						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
@@ -355,6 +382,22 @@
 					</object>
 					<int key="connectionID">31</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">delegate</string>
+						<reference key="source" ref="489647291"/>
+						<reference key="destination" ref="372490531"/>
+					</object>
+					<int key="connectionID">33</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">secondaryTextField</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="489647291"/>
+					</object>
+					<int key="connectionID">34</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -391,6 +434,7 @@
 							<reference ref="437425926"/>
 							<reference ref="39845841"/>
 							<reference ref="590720250"/>
+							<reference ref="489647291"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -444,6 +488,11 @@
 						<reference key="object" ref="590720250"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">32</int>
+						<reference key="object" ref="489647291"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -460,6 +509,7 @@
 					<string>15.IBPluginDependency</string>
 					<string>24.IBPluginDependency</string>
 					<string>29.IBPluginDependency</string>
+					<string>32.IBPluginDependency</string>
 					<string>6.IBEditorWindowLastContentRect</string>
 					<string>6.IBPluginDependency</string>
 					<string>8.IBPluginDependency</string>
@@ -469,6 +519,7 @@
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>DemoViewController</string>
 					<string>UIResponder</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -495,7 +546,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">31</int>
+			<int key="maxID">34</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -561,12 +612,14 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>activitySwitch</string>
+							<string>secondaryTextField</string>
 							<string>textField</string>
 							<string>topBottomSwitch</string>
 						</object>
 						<object class="NSMutableArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>UISwitch</string>
+							<string>UITextField</string>
 							<string>UITextField</string>
 							<string>UISwitch</string>
 						</object>
@@ -576,6 +629,7 @@
 						<object class="NSArray" key="dict.sortedKeys">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>activitySwitch</string>
+							<string>secondaryTextField</string>
 							<string>textField</string>
 							<string>topBottomSwitch</string>
 						</object>
@@ -584,6 +638,10 @@
 							<object class="IBToOneOutletInfo">
 								<string key="name">activitySwitch</string>
 								<string key="candidateClassName">UISwitch</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">secondaryTextField</string>
+								<string key="candidateClassName">UITextField</string>
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">textField</string>
@@ -610,6 +668,6 @@
 		</object>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">521</string>
+		<string key="IBCocoaTouchPluginVersion">301</string>
 	</data>
 </archive>

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.h
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.h
@@ -19,11 +19,13 @@ typedef enum {
 //You can access the label and the activity indicator to change its values. 
 //If you want to change the text or the activity itself, use textLabel and showActivity proprieties.
 @property (nonatomic, retain, readonly) UILabel *label;  
+@property (nonatomic, retain, readonly) UILabel *secondaryLabel;  
 @property (nonatomic, retain, readonly) UIActivityIndicatorView *activityIndicator;
 
 @property (nonatomic, assign) UIView *view; //The content view where the notification will be shown
 @property (nonatomic, assign) GCDiscreetNotificationViewPresentationMode presentationMode;
 @property (nonatomic, copy) NSString* textLabel;
+@property (nonatomic, copy) NSString* secondaryTextLabel;
 @property (nonatomic, assign) BOOL showActivity;
 
 @property (nonatomic, readonly, getter = isShowing) BOOL showing;
@@ -31,6 +33,10 @@ typedef enum {
 - (id) initWithText:(NSString *)text inView:(UIView *)aView;
 - (id) initWithText:(NSString *)text showActivity:(BOOL)activity inView:(UIView *)aView;
 - (id) initWithText:(NSString *)text showActivity:(BOOL)activity inPresentationMode:(GCDiscreetNotificationViewPresentationMode) aPresentationMode inView:(UIView *)aView;
+
+- (id) initWithText:(NSString *)text secondaryText:(NSString *)secondaryText inView:(UIView *)aView;
+- (id) initWithText:(NSString *)text secondaryText:(NSString *)secondaryText showActivity:(BOOL)activity inView:(UIView *)aView;
+- (id) initWithText:(NSString *)text secondaryText:(NSString *)secondaryText showActivity:(BOOL)activity inPresentationMode:(GCDiscreetNotificationViewPresentationMode) aPresentationMode inView:(UIView *)aView;
 
 //Show/Hide animated
 - (void) showAnimated;
@@ -44,6 +50,7 @@ typedef enum {
 //Change proprieties in a animated fashion
 //If you need to change propreties, you NEED to use these methods. Hiding, changing value, and show it back will NOT work.
 - (void) setTextLabel:(NSString *) aText animated:(BOOL) animated;
+- (void) setSecondaryTextLabel:(NSString *) aText animated:(BOOL) animated;
 - (void) setShowActivity:(BOOL) activity animated:(BOOL) animated;
 - (void) setTextLabel:(NSString *)aText andSetShowActivity:(BOOL)activity animated:(BOOL)animated;
 

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -250,6 +250,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         if (animated) [UIView commitAnimations]; 
 
         self.label.hidden = hide;
+        self.secondaryLabel.hidden = hide;
     }
 }
 

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -110,7 +110,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 #pragma mark Drawing and layout
 
 - (void) layoutSubviews {
-    BOOL withActivity = self.activityIndicator != nil;
+    BOOL withActivity = self.showActivity;
     CGFloat baseWidth = (2 * GCDiscreetNotificationViewBorderSize) + (withActivity * GCDiscreetNotificationViewPadding);
     
     CGFloat maxLabelWidth = self.view.frame.size.width - self.activityIndicator.frame.size.width * withActivity - baseWidth;
@@ -119,7 +119,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
     CGFloat secondaryTextSizeWidth = (self.secondaryTextLabel != nil) ? [self.secondaryTextLabel sizeWithFont:self.secondaryLabel.font constrainedToSize:maxLabelSize lineBreakMode:UILineBreakModeTailTruncation].width : 0;
     
     CGFloat width = (textSizeWidth > secondaryTextSizeWidth ? textSizeWidth : secondaryTextSizeWidth);
-    CGFloat activityIndicatorWidth = (self.activityIndicator != nil) ? self.activityIndicator.frame.size.width : 0;
+    CGFloat activityIndicatorWidth = (self.showActivity) ? self.activityIndicator.frame.size.width : 0;
     CGRect bounds = CGRectMake(0, 0, baseWidth + width + activityIndicatorWidth , GCDiscreetNotificationViewHeight);
     if (!CGRectEqualToRect(self.bounds, bounds)) { //The bounds have changed...
         self.bounds = bounds;
@@ -137,12 +137,14 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         self.secondaryLabel.hidden = YES;
     }
     
-    if (self.activityIndicator == nil) {
+    if (self.showActivity == NO) {
         self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, width, height);
+        self.activityIndicator.hidden = YES;
     }
     else {
         self.activityIndicator.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, GCDiscreetNotificationViewPadding, self.activityIndicator.frame.size.width, self.activityIndicator.frame.size.height);
         self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize + GCDiscreetNotificationViewPadding + self.activityIndicator.frame.size.width, 0, width, height);
+        self.activityIndicator.hidden = NO;
     }
     
     [self placeOnGrid];
@@ -336,7 +338,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 }
 
 - (BOOL) showActivity {
-    return (self.activityIndicator != nil);
+    return (self.activityIndicator != nil && self.secondaryLabel.text.length == 0);
 }
 
 - (void) setShowActivity:(BOOL) activity {

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -126,11 +126,23 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         [self setNeedsDisplay];
     }
 
-    self.secondaryLabel.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 15, width, 15);
-    if (self.activityIndicator == nil) self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, width, 15);
+    BOOL hasSecondaryText = self.secondaryLabel.text.length > 0;
+    CGFloat height = hasSecondaryText ? GCDiscreetNotificationViewHeight / 2 : GCDiscreetNotificationViewHeight;
+    
+    if (hasSecondaryText) {
+        self.secondaryLabel.hidden = NO;
+        self.secondaryLabel.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 15, width, height);
+    }
+    else {
+        self.secondaryLabel.hidden = YES;
+    }
+    
+    if (self.activityIndicator == nil) {
+        self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, width, height);
+    }
     else {
         self.activityIndicator.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, GCDiscreetNotificationViewPadding, self.activityIndicator.frame.size.width, self.activityIndicator.frame.size.height);
-        self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize + GCDiscreetNotificationViewPadding + self.activityIndicator.frame.size.width, 0, width, 15);
+        self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize + GCDiscreetNotificationViewPadding + self.activityIndicator.frame.size.width, 0, width, height);
     }
     
     [self placeOnGrid];

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -126,7 +126,6 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         [self setNeedsDisplay];
     }
 
-#warning Temp code
     self.secondaryLabel.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 15, width, 15);
     if (self.activityIndicator == nil) self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, width, 15);
     else {

--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -17,6 +17,7 @@ NSString* const GCHideAnimation = @"hide";
 NSString* const GCChangeProprety = @"changeProprety";
 
 NSString* const GCDiscreetNotificationViewTextKey = @"text";
+NSString* const GCDiscreetNotificationViewSecondaryTextKey = @"secondaryText";
 NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 
 @interface GCDiscreetNotificationView ()
@@ -33,7 +34,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 - (void) animationDidStop:(NSString *)animationID finished:(BOOL) finished context:(void *) context;
 
 - (void) placeOnGrid;
-- (void) changePropretyAnimatedWithKeys:(NSArray*) keys values:(NSArray*) values;
+- (void) changePropertyAnimatedWithKeys:(NSArray*) keys values:(NSArray*) values;
 
 @end
 
@@ -43,24 +44,38 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 @synthesize presentationMode;
 @synthesize view;
 @synthesize label;
+@synthesize secondaryLabel;
 @synthesize animating, animationDict;
 
 #pragma mark -
 #pragma mark Init and dealloc
 
 - (id) initWithText:(NSString *)text inView:(UIView *)aView {
-    return [self initWithText:text showActivity:NO inView:aView];
+    return [self initWithText:text secondaryText:nil inView:aView];
 }
 
-- (id)initWithText:(NSString*) text showActivity:(BOOL) activity inView:(UIView*) aView {
-    return [self initWithText:text showActivity:activity inPresentationMode:GCDiscreetNotificationViewPresentationModeTop inView:aView];
+- (id) initWithText:(NSString *)text showActivity:(BOOL)activity inView:(UIView *)aView {
+    return [self initWithText:text secondaryText:nil showActivity:activity inView:aView];
 }
 
-- (id) initWithText:(NSString *)text showActivity:(BOOL)activity 
+- (id) initWithText:(NSString *)text showActivity:(BOOL)activity inPresentationMode:(GCDiscreetNotificationViewPresentationMode) aPresentationMode inView:(UIView *)aView {
+    return [self initWithText:text secondaryText:nil showActivity:activity inPresentationMode:aPresentationMode inView:aView];
+}
+
+- (id) initWithText:(NSString *)text secondaryText:(NSString *)secondaryText inView:(UIView *)aView {
+    return [self initWithText:text secondaryText:secondaryText showActivity:NO inView:aView];
+}
+
+- (id)initWithText:(NSString*) text secondaryText:(NSString *)secondaryText showActivity:(BOOL) activity inView:(UIView*) aView {
+    return [self initWithText:text secondaryText:secondaryText showActivity:activity inPresentationMode:GCDiscreetNotificationViewPresentationModeTop inView:aView];
+}
+
+- (id) initWithText:(NSString *)text secondaryText:(NSString *)secondaryText showActivity:(BOOL)activity 
  inPresentationMode:(GCDiscreetNotificationViewPresentationMode)aPresentationMode inView:(UIView *)aView {
     if ((self = [super initWithFrame:CGRectZero])) {
         self.view = aView;
         self.textLabel = text;
+        self.secondaryTextLabel = secondaryText;
         self.showActivity = activity;
         self.presentationMode = aPresentationMode;
         
@@ -82,6 +97,9 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
     [label release];
     label = nil;
     
+    [secondaryLabel release];
+    secondaryLabel = nil;
+    
     [activityIndicator release];
     activityIndicator = nil;
     
@@ -98,17 +116,22 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
     CGFloat maxLabelWidth = self.view.frame.size.width - self.activityIndicator.frame.size.width * withActivity - baseWidth;
     CGSize maxLabelSize = CGSizeMake(maxLabelWidth, GCDiscreetNotificationViewHeight);
     CGSize textSize = [self.textLabel sizeWithFont:self.label.font constrainedToSize:maxLabelSize lineBreakMode:UILineBreakModeTailTruncation];
+    CGSize secondaryTextSize = [self.secondaryTextLabel sizeWithFont:self.secondaryLabel.font constrainedToSize:maxLabelSize lineBreakMode:UILineBreakModeTailTruncation];
     
-    CGRect bounds = CGRectMake(0, 0, baseWidth + textSize.width + (self.activityIndicator != nil) * self.activityIndicator.frame.size.width , GCDiscreetNotificationViewHeight);
+    CGFloat width = (textSize.width > secondaryTextSize.width ? textSize.width : secondaryTextSize.width);
+    CGRect bounds = CGRectMake(0, 0, baseWidth + width +
+                               (self.activityIndicator != nil) * self.activityIndicator.frame.size.width , GCDiscreetNotificationViewHeight);
     if (!CGRectEqualToRect(self.bounds, bounds)) { //The bounds have changed...
         self.bounds = bounds;
         [self setNeedsDisplay];
     }
-    
-    if (self.activityIndicator == nil) self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, textSize.width, 30);
+
+#warning Temp code
+    self.secondaryLabel.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 15, width, 15);
+    if (self.activityIndicator == nil) self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, 0, width, 15);
     else {
         self.activityIndicator.frame = CGRectMake(GCDiscreetNotificationViewBorderSize, GCDiscreetNotificationViewPadding, self.activityIndicator.frame.size.width, self.activityIndicator.frame.size.height);
-        self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize + GCDiscreetNotificationViewPadding + self.activityIndicator.frame.size.width, 0, textSize.width, 30);
+        self.label.frame = CGRectMake(GCDiscreetNotificationViewBorderSize + GCDiscreetNotificationViewPadding + self.activityIndicator.frame.size.width, 0, width, 15);
     }
     
     [self placeOnGrid];
@@ -254,6 +277,15 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
     [self setNeedsLayout];
 }
 
+- (NSString *) secondaryTextLabel {
+    return self.secondaryLabel.text;
+}
+
+- (void) setSecondaryTextLabel:(NSString *) aText {
+    self.secondaryLabel.text = aText;
+    [self setNeedsLayout];
+}
+
 - (UILabel *)label {
     if (label == nil) {
         label = [[UILabel alloc] init];
@@ -264,10 +296,28 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
         label.shadowOffset = CGSizeMake(0, 1);
         label.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
         label.backgroundColor = [UIColor clearColor];
+        label.textAlignment = UITextAlignmentCenter;
         
         [self addSubview:label];
     }
     return label;
+}
+
+- (UILabel *)secondaryLabel {
+    if (secondaryLabel == nil) {
+        secondaryLabel = [[UILabel alloc] init];
+        
+        secondaryLabel.font = [UIFont systemFontOfSize:12.0];
+        secondaryLabel.textColor = [UIColor whiteColor];
+        secondaryLabel.shadowColor = [UIColor blackColor];
+        secondaryLabel.shadowOffset = CGSizeMake(0, 1);
+        secondaryLabel.baselineAdjustment = UIBaselineAdjustmentAlignCenters;
+        secondaryLabel.backgroundColor = [UIColor clearColor];
+        secondaryLabel.textAlignment = UITextAlignmentCenter;
+        
+        [self addSubview:secondaryLabel];
+    }
+    return secondaryLabel;
 }
 
 - (BOOL) showActivity {
@@ -346,15 +396,23 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 
 - (void) setTextLabel:(NSString *)aText animated:(BOOL)animated {
     if (animated && (self.showing || self.animating)) {
-        [self changePropretyAnimatedWithKeys:[NSArray arrayWithObject:GCDiscreetNotificationViewTextKey]
+        [self changePropertyAnimatedWithKeys:[NSArray arrayWithObject:GCDiscreetNotificationViewTextKey]
                                       values:[NSArray arrayWithObject:aText]];
     }
     else self.textLabel = aText;
 }
 
+- (void) setSecondaryTextLabel:(NSString *)aText animated:(BOOL)animated {
+    if (animated && (self.showing || self.animating)) {
+        [self changePropertyAnimatedWithKeys:[NSArray arrayWithObject:GCDiscreetNotificationViewSecondaryTextKey]
+                                      values:[NSArray arrayWithObject:aText]];
+    }
+    else self.secondaryTextLabel = aText;
+}
+
 - (void) setShowActivity:(BOOL)activity animated:(BOOL)animated {
     if (animated && (self.showing || self.animating)) {
-        [self changePropretyAnimatedWithKeys:[NSArray arrayWithObject:GCDiscreetNotificationViewActivityKey]
+        [self changePropertyAnimatedWithKeys:[NSArray arrayWithObject:GCDiscreetNotificationViewActivityKey]
                                       values:[NSArray arrayWithObject:[NSNumber numberWithBool:activity]]];
     }
     else self.showActivity = activity;
@@ -362,7 +420,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 
 - (void) setTextLabel:(NSString *)aText andSetShowActivity:(BOOL)activity animated:(BOOL)animated {
     if (animated && (self.showing || self.animating)) {
-        [self changePropretyAnimatedWithKeys:[NSArray arrayWithObjects:GCDiscreetNotificationViewTextKey, GCDiscreetNotificationViewActivityKey, nil]
+        [self changePropertyAnimatedWithKeys:[NSArray arrayWithObjects:GCDiscreetNotificationViewTextKey, GCDiscreetNotificationViewActivityKey, nil]
                                       values:[NSArray arrayWithObjects:aText, [NSNumber numberWithBool:activity], nil]];
     }
     else {
@@ -383,7 +441,7 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
     self.frame = frame;
 }
 
-- (void) changePropretyAnimatedWithKeys:(NSArray*) keys values:(NSArray*) values {
+- (void) changePropertyAnimatedWithKeys:(NSArray*) keys values:(NSArray*) values {
     NSDictionary* newDict = [NSDictionary dictionaryWithObjects:values forKeys:keys];
     
     if (self.animationDict == nil) {


### PR DESCRIPTION
This feature adds an optional secondary line of text in a smaller font, displayed below the primary text. If no secondary text is provided, then the view behaves as it did before i.e. a single line of text is displayed, centred vertically in the view.

If secondary text is provided but no primary text is given, then the secondary text is treated as the primary text.

Currently, the activity indicator is not displayed is both primary and secondary text are specified.
