### PR TITLE
Cancel the previous `hideAnimated` if the view was moved to a nil superview.

### DIFF
--- a/GCDiscreetNotificationView/GCDiscreetNotificationView.m
+++ b/GCDiscreetNotificationView/GCDiscreetNotificationView.m
@@ -409,7 +409,10 @@ NSString* const GCDiscreetNotificationViewActivityKey = @"activity";
 #pragma mark - UIView subclass
 
 - (void)willMoveToSuperview:(UIView *)newSuperview {
-    if (newSuperview == nil) self.animationDict = nil;
+    if (newSuperview == nil) {
+        self.animationDict = nil;
+        [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(hideAnimated) object:nil];
+    }
 }
 
 @end


### PR DESCRIPTION
This fixes a crash if the view is removed before the hiding begins.
